### PR TITLE
ローカル開発用にデータベース設定ファイルを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Install
 
 ```
-$ npm install
-$ node app.js
+$ cp config/database.yml.example config/database.yml
+  # Edit your mysql connect config
+$ $EDITOR config/database.yml
+$ bundle install
+$ bundle exec rake db:migrate
+$ bundle exec rails s
 ```
 
-# see also  
+# see also
 https://ruffnote.com/pandeiro245/245cloud

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,0 +1,23 @@
+development:
+  adapter: mysql2
+  database: 245cloud_development
+  host: localhost
+  username: root
+  password: ""
+  encoding: utf8
+
+production:
+  adapter: mysql2
+  database: 245cloud
+  host: localhost
+  username: root
+  password: ""
+  encoding: utf8
+
+test:
+  adapter: mysql2
+  database: 245cloud_test
+  host: localhost
+  username: root
+  password: ""
+  encoding: utf8


### PR DESCRIPTION
## 目的

ローカルでrails server立ち上げると以下のメッセージが出て起動できない
「could not load database configuration. No such file - ["config/database.yml"]」

## Todo

- [x] config/development.ymlを追加する
- [x] READMEにインストール手順を追記

もしくは config/development.yml.example を作成して
cloneしたら renameしてもらう。 redmineがそうなってました。

~~~
  production:
    adapter: mysql2
    database: 245cloud
    host: localhost
    username: root
    password: ""
    encoding: utf8

  development:
    adapter: mysql2
    database: 245cloud_development
    host: localhost
    username: root
    password: ""
    encoding: utf8

  test:
    adapter: mysql2
    database: 245cloud_test
    host: localhost
    username: root
~~~