### PR TITLE
add auto_start and auto_close

### DIFF
--- a/app/assets/javascripts/main.coffee
+++ b/app/assets/javascripts/main.coffee
@@ -128,6 +128,8 @@ initNaotake = () ->
 initStart = () ->
   if location.href.match(/sparta/)
     Util.countDown(1*60*1000, start_unless_doing)
+  if location.href.match(/auto_start=/)
+    start_unless_doing()
 
   text = "24分やり直しでも大丈夫ですか？"
   Util.beforeunload(text, 'env.is_doing')
@@ -832,7 +834,11 @@ window.updateUnreads = (room_id, count) ->
 window.finish = () ->
   console.log 'finish'
   @syncWorkload('finish')
-  location.reload()
+  if location.href.match(/auto_close=/)
+    window.open(location, '_self', '')
+    window.close()
+  else
+    location.reload()
 
 window.createComment = (room_id) ->
   console.log 'createComment'


### PR DESCRIPTION
Macで

```
open http://245cloud.com/?auto_start=1&auto_close=1#mixcloud:/kimiya-sato/filterdmix-2/
```

みたいにやると
（ハッシュがあるとその音楽が、なければ無音で）自動で24分がスタートして
５分休憩が終わったら勝手に閉じてくれます。

ただし、chromeのURL欄にこのURLを実行しても
auto_startはうまくいくものの、auto_closeでは

```
Scripts may close only the windows that were opened by it.
```

となります。