### PR TITLE
Fix #338: ニコニコ動画の iframe が head 内に入ってしまって再生されない問題を修正

### DIFF
--- a/app/assets/javascripts/lib/nicovideo.coffee
+++ b/app/assets/javascripts/lib/nicovideo.coffee
@@ -27,9 +27,11 @@ class @Nicovideo
       $dom.html(msg)
       document.write = document._write
 
+    # append する前に src を設定しちゃうと iframe が head の中に入っちゃう.
+    # …ので、append した後に src を設定する.
     script = document.createElement('script')
-    script.src = "http://ext.nicovideo.jp/thumb_watch/#{sm_id}"
     $dom.append(script)
+    script.src = "http://ext.nicovideo.jp/thumb_watch/#{sm_id}"
 
   @search: (keyword, $dom, callback=null) ->
     url = "http://api.search.nicovideo.jp/api/snapshot/"


### PR DESCRIPTION
refs #338

修正前のコードだと、
```
script = document.createElement('script')
script.src = "http://ext.nicovideo.jp/thumb_watch/#{sm_id}"
```
ここまで実行した時点（scriptの親が無い時点）で nicovideo 側のスクリプトが実行されてしまい、 iframe の注入場所がおかしくなるみたいでした。
script.src は append した後に設定するようにすると、期待の位置に iframe が注入されます。
