### PR TITLE
検索結果やその他レコメンドの曲情報に枠線を付ける

### DIFF
--- a/app/assets/javascripts/lib/eight_tracks.coffee
+++ b/app/assets/javascripts/lib/eight_tracks.coffee
@@ -27,7 +27,7 @@ class @EightTracks
             artwork = "<img src=\"#{track.artwork_url}\" width='100px'/>"
           href = "soundcloud:#{track.id}"
           $dom.append("""
-            <div class='col-lg-2' style='min-height: 200px;'>
+            <div class='track_item col-lg-2' style='min-height: 200px;'>
               <a href='#{track.permalink_url}' target='_blank'>#{track.title}</a>
               (#{Util.time(track.duration)})<br />
               <br />
@@ -51,7 +51,7 @@ class @EightTracks
             artwork = "<img src=\"#{a.sq100}\" width='100px'/>"
           href = "8tracks:#{track.id}"
           $dom.append("""
-            <div class='col-lg-2' style='min-height: 200px;'>
+            <div class='track_item col-lg-2' style='min-height: 200px;'>
               <a href='#{track.restful_url}' target='_blank'>#{track.name}</a>
               (#{Util.time(track.duration * 1000)})<br />
               <br />

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -250,6 +250,12 @@ table.comments .icon{
   margin-right: 8px;
 }
 
+/* タイトル部の左右は現状維持 */
+#header.scaffold.row {
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
 /* 再生中一覧の枠の左側の隙間は現状を維持。右側にちょっと余裕がないので少し隙間をあける */
 #doing, #chatting, #done, #you {
   margin-left: -8px;

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -227,3 +227,31 @@ table.comments .icon{
   margin: 3px;
   border-radius: 8px;
 }
+
+/* 検索結果のボックスを薄い枠で囲む */
+.track_item {
+    border: 1px solid #ccc;
+    margin: 4px;
+    padding: 0px 2px;
+    border-radius: 4px;
+}
+
+.track_item .fixed_start img {
+    margin-bottom: 8px;
+}
+
+/* 検索結果一覧の左右枠に余裕がないので少し隙間をあける */
+.scaffold.row {
+    margin-left: 0px;
+    margin-right: 0px;
+}
+#nc {
+    margin-left: 8px;
+    margin-right: 8px;
+}
+
+/* 再生中一覧の枠の左側の隙間は現状を維持。右側にちょっと余裕がないので少し隙間をあける */
+#doing, #chatting, #done, #you {
+    margin-left: -8px;
+    margin-right: 18px;
+}

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -230,28 +230,28 @@ table.comments .icon{
 
 /* 検索結果のボックスを薄い枠で囲む */
 .track_item {
-    border: 1px solid #ccc;
-    margin: 4px;
-    padding: 0px 2px;
-    border-radius: 4px;
+  border: 1px solid #ccc;
+  margin: 4px;
+  padding: 0px 2px;
+  border-radius: 4px;
 }
 
 .track_item .fixed_start img {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 
 /* 検索結果一覧の左右枠に余裕がないので少し隙間をあける */
 .scaffold.row {
-    margin-left: 0px;
-    margin-right: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
 }
 #nc {
-    margin-left: 8px;
-    margin-right: 8px;
+  margin-left: 8px;
+  margin-right: 8px;
 }
 
 /* 再生中一覧の枠の左側の隙間は現状を維持。右側にちょっと余裕がないので少し隙間をあける */
 #doing, #chatting, #done, #you {
-    margin-left: -8px;
-    margin-right: 18px;
+  margin-left: -8px;
+  margin-right: 18px;
 }


### PR DESCRIPTION
検索結果や「〇〇さんMIX」みたいなところに出てくる曲情報に薄い枠線を付けてみました。
あと、全体的に左右マージンに余裕が無いように見えたのでちょっとだけ全体的な調整入れてます。どうでしょう？

## Before
<img  alt="before" src="https://cloud.githubusercontent.com/assets/2929454/21087371/8eca9ea6-c068-11e6-89af-b0349b0dd495.png">

## After
<img alt="after" src="https://cloud.githubusercontent.com/assets/2929454/21087374/90d8f99a-c068-11e6-8d11-870ce5c42eae.png">
