### PR TITLE
Fixed seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,2 @@
-Workload.sync
+Util.sync
 Comment.sync


### PR DESCRIPTION
# WHAT IS THIS

Hi, I found that `rake db:seed` does not work.

Because `Workload.sync` is already deleted & refactored by this PR ( https://github.com/pandeiro245/245cloud/pull/255 ).

So, I fixed it.

```
$ bundle exec rake db:seed
rake aborted!
NoMethodError: undefined method `sync' for #<Class:0x007f90de7bef00>
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```

# AFTER

```
$ bundle exec rake db:seed
done
done
```