### PR TITLE
Scroll to login-button position if trying to play without login

### DIFF
--- a/app/assets/javascripts/main.coffee
+++ b/app/assets/javascripts/main.coffee
@@ -860,6 +860,7 @@ initFixedStart = () ->
       start_hash()
     else
       alert 'Facebookログインをお願いします！'
+      $('html,body').animate({scrollTop:$('#login').offset().top - 40}) # Scroll to the login button position.
       window.fbAsyncInit()
   )
   $(document).on('click', '.add_playlist', () ->


### PR DESCRIPTION
Facebookログインが必要なアラートが出たときに
![](https://cloud.githubusercontent.com/assets/2929454/25261591/9e7414e6-268d-11e7-8ea5-d5775c0c6dd4.png)

自動でログインボタンの位置までスクロールします
![](https://cloud.githubusercontent.com/assets/2929454/25261589/9bf737ac-268d-11e7-96b9-d208057a0ad1.png)

