### PR TITLE
Fix youtube duration calculation so as not to be NaN

### DIFF
--- a/app/assets/javascripts/main.coffee
+++ b/app/assets/javascripts/main.coffee
@@ -476,7 +476,8 @@ start = () ->
   Util.countDown(@env.pomotime*60*1000, complete)
 
 window.youtubeDurationSec = (key)  ->
-  duration = key['contentDetails']['duration'].replace(/^PT/, '').replace(/S$/, '')
+  duration = key['contentDetails']['duration'];            # Ex) "PT43M22S", "PT43M"
+  duration = duration.replace(/^PT/, '').replace(/S$/, '') # Ex) "43M22", "43M"
 
   console.log duration
   if duration.match(/H/)
@@ -485,8 +486,8 @@ window.youtubeDurationSec = (key)  ->
   else
     hour = 0
     d2 = duration
-  min = parseInt(d2.split('M')[0])
-  sec = parseInt(d2.split('M')[1])
+  min = parseInt(d2.split('M')[0]) || 0
+  sec = parseInt(d2.split('M')[1]) || 0
   sec = hour*60*60+min*60+sec
   parseInt(sec)
 


### PR DESCRIPTION
The youtube duration calculation in ```youtubeDurationSec()``` had a problem as follows.

If the value of ```key['contentDetails']['duration']``` is like "PT43M22S", the calculation had worked well.
But if the value of that is like "PT43M", the calculation had returned NaN.
"PT43M" should be treated as "PT43M00S" (43 minutes and 0 second.)

This PR fixes it.

## Youtube example
- https://www.youtube.com/watch?v=DtSWpsPsiLg ... duration string = "PT43M22S"
- https://www.youtube.com/watch?v=7qtXr8UziBA ... duration string = "PT30M"
